### PR TITLE
Issue #15

### DIFF
--- a/src/main/java/org/ehcache/sizeof/impl/AgentLoader.java
+++ b/src/main/java/org/ehcache/sizeof/impl/AgentLoader.java
@@ -148,7 +148,7 @@ final class AgentLoader {
                         "They both result in a bug, not yet fixed by Apple, that won't let us attach to the VM and load the agent.\n" +
                         "Most probably, you'll also get a full thread-dump after this because of the failure... Nothing to worry about!\n" +
                         "You can bypass trying to load the Agent entirely by setting the System property '"
-                        + net.sf.ehcache.pool.sizeof.AgentSizeOf.BYPASS_LOADING + "'  to true");
+                        + AgentSizeOf.BYPASS_LOADING + "'  to true");
         }
     }
 

--- a/src/main/java/org/ehcache/sizeof/impl/AgentSizeOf.java
+++ b/src/main/java/org/ehcache/sizeof/impl/AgentSizeOf.java
@@ -34,7 +34,7 @@ public class AgentSizeOf extends SizeOf {
     /**
      * System property name to bypass attaching to the VM and loading of Java agent to measure Object sizes.
      */
-    public static final String BYPASS_LOADING = "net.sf.ehcache.pool.sizeof.AgentSizeOf.bypass";
+    public static final String BYPASS_LOADING = "org.ehcache.sizeof.AgentSizeOf.bypass";
 
     private static final boolean AGENT_LOADED = !Boolean.getBoolean(BYPASS_LOADING) && AgentLoader.loadAgent();
 


### PR DESCRIPTION
All other worked happened. With that change, sizeof should be usable without Ehcache on the class path. Only the service loader stuff still uses ehcache now
