### PR TITLE
Remove support on obsolete JVMs and pre-Java 8 JVMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
@@ -55,12 +61,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/ehcache/sizeof/impl/JvmInformation.java
+++ b/src/main/java/org/ehcache/sizeof/impl/JvmInformation.java
@@ -282,85 +282,6 @@ public enum JvmInformation {
     },
 
     /**
-     * Represents 32-Bit JRockit JVM"
-     */
-    JROCKIT_32_BIT(UNKNOWN_32_BIT) {
-
-        @Override
-        public int getAgentSizeOfAdjustment() {
-            return 8;
-        }
-
-        @Override
-        public int getFieldOffsetAdjustment() {
-            return 8;
-        }
-
-        @Override
-        public int getObjectHeaderSize() {
-            return 16;
-        }
-
-        @Override
-        public String getJvmDescription() {
-            return "32-Bit JRockit JVM";
-        }
-
-        @Override
-        public boolean supportsReflectionSizeOf() {
-            return false;
-        }
-    },
-
-    /**
-     * Represents 64-Bit JRockit JVM (with no reference compression)
-     */
-    JROCKIT_64_BIT(JROCKIT_32_BIT) {
-
-        @Override
-        public int getObjectHeaderSize() {
-            return 16;
-        }
-
-        @Override
-        public String getJvmDescription() {
-            return "64-Bit JRockit JVM (with no reference compression)";
-        }
-    },
-
-    /**
-     * Represents 64-Bit JRockit JVM with 64GB Compressed References
-     */
-    JROCKIT_64_BIT_WITH_64GB_COMPRESSED_REFS(JROCKIT_32_BIT) {
-
-
-        @Override
-        public int getObjectAlignment() {
-            return 16;
-        }
-
-        @Override
-        public int getAgentSizeOfAdjustment() {
-            return 16;
-        }
-
-        @Override
-        public int getFieldOffsetAdjustment() {
-            return 16;
-        }
-
-        @Override
-        public int getObjectHeaderSize() {
-            return 24;
-        }
-
-        @Override
-        public String getJvmDescription() {
-            return "64-Bit JRockit JVM with 64GB Compressed References";
-        }
-    },
-
-    /**
      * Represents IBM 32-bit
      */
     IBM_32_BIT(UNKNOWN_32_BIT) {
@@ -527,9 +448,6 @@ public enum JvmInformation {
         }
 
         if (jif == null) {
-            jif = detectJRockit();
-        }
-        if (jif == null) {
             jif = detectIBM();
         }
 
@@ -590,24 +508,6 @@ public enum JvmInformation {
                 } else {
                     jif = OPENJDK_32_BIT;
                 }
-            }
-        }
-
-        return jif;
-    }
-
-    private static JvmInformation detectJRockit() {
-        JvmInformation jif = null;
-
-        if (isJRockit()) {
-            if (is64Bit()) {
-                if (isJRockit64GBCompression()) {
-                    jif = JROCKIT_64_BIT_WITH_64GB_COMPRESSED_REFS;
-                } else {
-                    jif = JROCKIT_64_BIT;
-                }
-            } else {
-                jif = JROCKIT_32_BIT;
             }
         }
 

--- a/src/test/java/org/ehcache/sizeof/ObjectGraphWalkerTest.java
+++ b/src/test/java/org/ehcache/sizeof/ObjectGraphWalkerTest.java
@@ -76,29 +76,18 @@ public class ObjectGraphWalkerTest {
         },
             true);
 
-        String javaVersion = System.getProperty("java.version");
-        if (javaVersion.startsWith("1.5")) {
-            assertThat(walker.walk(new ReentrantReadWriteLock()), is(4L));
-        } else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8")) {
-            assertThat(walker.walk(new ReentrantReadWriteLock()), is(5L));
-            assertThat(map.remove("java.util.concurrent.locks.ReentrantReadWriteLock$Sync$ThreadLocalHoldCounter"), is(1L));
-        } else {
-            throw new AssertionError("Unexpected Java Version : " + javaVersion);
-        }
+        assertThat(walker.walk(new ReentrantReadWriteLock()), is(5L));
+        assertThat(map.remove("java.util.concurrent.locks.ReentrantReadWriteLock$Sync$ThreadLocalHoldCounter"), is(1L));
+
         assertThat(map.remove(ReentrantReadWriteLock.class.getName()), is(1L));
         assertThat(map.remove("java.util.concurrent.locks.ReentrantReadWriteLock$NonfairSync"), is(1L));
         assertThat(map.remove(ReentrantReadWriteLock.ReadLock.class.getName()), is(1L));
         assertThat(map.remove(ReentrantReadWriteLock.WriteLock.class.getName()), is(1L));
         assertThat(map.isEmpty(), is(true));
 
-        if (javaVersion.startsWith("1.5")) {
-            assertThat(walker.walk(new SomeInnerClass()), is(13L));
-        } else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8")) {
-            assertThat(walker.walk(new SomeInnerClass()), is(14L));
-            assertThat(map.remove("java.util.concurrent.locks.ReentrantReadWriteLock$Sync$ThreadLocalHoldCounter"), is(1L));
-        } else {
-            throw new AssertionError("Unexpected Java Version : " + javaVersion);
-        }
+        assertThat(walker.walk(new SomeInnerClass()), is(14L));
+        assertThat(map.remove("java.util.concurrent.locks.ReentrantReadWriteLock$Sync$ThreadLocalHoldCounter"), is(1L));
+
         assertThat(map.remove(SomeInnerClass.class.getName()), is(1L));
         assertThat(map.remove(this.getClass().getName()), is(1L));
         assertThat(map.remove(Object.class.getName()), is(5L));

--- a/src/test/java/org/ehcache/sizeof/SizeOfTestValues.java
+++ b/src/test/java/org/ehcache/sizeof/SizeOfTestValues.java
@@ -32,8 +32,6 @@ public class SizeOfTestValues {
     private static final Map<JvmInformation, Map<String, Long>> CORRECT_SIZES = new EnumMap<>(JvmInformation.class);
 
     static {
-        int jvmVersion = Integer.parseInt(System.getProperty("java.version").substring(2, 3));
-
         Map<String, Long> hotspot32Bit = new HashMap<>();
         hotspot32Bit.put("sizeOf(new Object())", 8L);
         hotspot32Bit.put("sizeOf(new Integer(1))", 16L);
@@ -47,18 +45,8 @@ public class SizeOfTestValues {
         hotspot32Bit.put("deepSizeOf(new Pair(null, null))", 16L);
         hotspot32Bit.put("deepSizeOf(new Pair(new Object(), null))", 24L);
         hotspot32Bit.put("deepSizeOf(new Pair(new Object(), new Object()))", 32L);
-        switch (jvmVersion) {
-            case 5:
-                hotspot32Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 80L);
-                break;
-            case 6:
-                hotspot32Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 104L);
-                break;
-            case 7:
-            case 8:
-                hotspot32Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
-                break;
-        }
+        hotspot32Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
+
         CORRECT_SIZES.put(JvmInformation.HOTSPOT_32_BIT, hotspot32Bit);
         CORRECT_SIZES.put(JvmInformation.OPENJDK_32_BIT, hotspot32Bit);
 
@@ -75,18 +63,8 @@ public class SizeOfTestValues {
         hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new Pair(null, null))", 16L);
         hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new Pair(new Object(), null))", 24L);
         hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new Pair(new Object(), new Object()))", 32L);
-        switch (jvmVersion) {
-            case 5:
-                hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new ReentrantReadWriteLock())", 80L);
-                break;
-            case 6:
-                hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new ReentrantReadWriteLock())", 104L);
-                break;
-            case 7:
-            case 8:
-                hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
-                break;
-        }
+        hotspot32BitWithConcurrentMarkAndSweep.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
+
         CORRECT_SIZES.put(JvmInformation.HOTSPOT_32_BIT_WITH_CONCURRENT_MARK_AND_SWEEP, hotspot32BitWithConcurrentMarkAndSweep);
         CORRECT_SIZES.put(JvmInformation.OPENJDK_32_BIT_WITH_CONCURRENT_MARK_AND_SWEEP, hotspot32BitWithConcurrentMarkAndSweep);
 
@@ -103,18 +81,8 @@ public class SizeOfTestValues {
         hotspot64Bit.put("deepSizeOf(new Pair(null, null))", 32L);
         hotspot64Bit.put("deepSizeOf(new Pair(new Object(), null))", 48L);
         hotspot64Bit.put("deepSizeOf(new Pair(new Object(), new Object()))", 64L);
-        switch (jvmVersion) {
-            case 5:
-                hotspot64Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 136L);
-                break;
-            case 6:
-                hotspot64Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 176L);
-                break;
-            case 7:
-            case 8:
-                hotspot64Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 192L);
-                break;
-        }
+        hotspot64Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 192L);
+
         CORRECT_SIZES.put(JvmInformation.HOTSPOT_64_BIT, hotspot64Bit);
         CORRECT_SIZES.put(JvmInformation.OPENJDK_64_BIT, hotspot64Bit);
 
@@ -131,18 +99,8 @@ public class SizeOfTestValues {
         hotspot64BitWithCMS.put("deepSizeOf(new Pair(null, null))", 32L);
         hotspot64BitWithCMS.put("deepSizeOf(new Pair(new Object(), null))", 48L);
         hotspot64BitWithCMS.put("deepSizeOf(new Pair(new Object(), new Object()))", 64L);
-        switch (jvmVersion) {
-            case 5:
-                hotspot64BitWithCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 136L);
-                break;
-            case 6:
-                hotspot64BitWithCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 176L);
-                break;
-            case 7:
-            case 8:
-                hotspot64BitWithCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 192L);
-                break;
-        }
+        hotspot64BitWithCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 192L);
+
         CORRECT_SIZES.put(JvmInformation.HOTSPOT_64_BIT_WITH_CONCURRENT_MARK_AND_SWEEP, hotspot64BitWithCMS);
         CORRECT_SIZES.put(JvmInformation.OPENJDK_64_BIT_WITH_CONCURRENT_MARK_AND_SWEEP, hotspot64BitWithCMS);
 
@@ -159,15 +117,8 @@ public class SizeOfTestValues {
         hotspot64BitWithCompressedOops.put("deepSizeOf(new Pair(null, null))", 24L);
         hotspot64BitWithCompressedOops.put("deepSizeOf(new Pair(new Object(), null))", 40L);
         hotspot64BitWithCompressedOops.put("deepSizeOf(new Pair(new Object(), new Object()))", 56L);
-        switch (jvmVersion) {
-            case 6:
-                hotspot64BitWithCompressedOops.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
-                break;
-            case 7:
-            case 8:
-                hotspot64BitWithCompressedOops.put("deepSizeOf(new ReentrantReadWriteLock())", 120L);
-                break;
-        }
+        hotspot64BitWithCompressedOops.put("deepSizeOf(new ReentrantReadWriteLock())", 120L);
+
         CORRECT_SIZES.put(JvmInformation.HOTSPOT_64_BIT_WITH_COMPRESSED_OOPS, hotspot64BitWithCompressedOops);
         CORRECT_SIZES.put(JvmInformation.OPENJDK_64_BIT_WITH_COMPRESSED_OOPS, hotspot64BitWithCompressedOops);
 
@@ -184,41 +135,10 @@ public class SizeOfTestValues {
         hotspot64BitWithCompressedOopsAndCMS.put("deepSizeOf(new Pair(null, null))", 24L);
         hotspot64BitWithCompressedOopsAndCMS.put("deepSizeOf(new Pair(new Object(), null))", 40L);
         hotspot64BitWithCompressedOopsAndCMS.put("deepSizeOf(new Pair(new Object(), new Object()))", 56L);
-        switch (jvmVersion) {
-            case 6:
-                hotspot64BitWithCompressedOopsAndCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
-                break;
-            case 7:
-            case 8:
-                hotspot64BitWithCompressedOopsAndCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 120L);
-                break;
-        }
+        hotspot64BitWithCompressedOopsAndCMS.put("deepSizeOf(new ReentrantReadWriteLock())", 120L);
+
         CORRECT_SIZES.put(JvmInformation.HOTSPOT_64_BIT_WITH_COMPRESSED_OOPS_AND_CONCURRENT_MARK_AND_SWEEP, hotspot64BitWithCompressedOopsAndCMS);
         CORRECT_SIZES.put(JvmInformation.OPENJDK_64_BIT_WITH_COMPRESSED_OOPS_AND_CONCURRENT_MARK_AND_SWEEP, hotspot64BitWithCompressedOopsAndCMS);
-
-        Map<String, Long> jrockit32Bit = new HashMap<>();
-        jrockit32Bit.put("sizeOf(new Object())", 16L);
-        jrockit32Bit.put("sizeOf(new Integer(1))", 24L);
-        jrockit32Bit.put("sizeOf(1000)", 24L);
-        jrockit32Bit.put("deepSizeOf(new SomeClass(false))", 24L);
-        jrockit32Bit.put("deepSizeOf(new SomeClass(true))", 40L);
-        jrockit32Bit.put("sizeOf(new Object[] { })", 24L);
-        jrockit32Bit.put("sizeOf(new Object[] { new Object(), new Object(), new Object(), new Object() })", 40L);
-        jrockit32Bit.put("sizeOf(new int[] { })", 24L);
-        jrockit32Bit.put("sizeOf(new int[] { 987654, 876543, 765432, 654321 })", 40L);
-        jrockit32Bit.put("deepSizeOf(new Pair(null, null))", 24L);
-        jrockit32Bit.put("deepSizeOf(new Pair(new Object(), null))", 40L);
-        jrockit32Bit.put("deepSizeOf(new Pair(new Object(), new Object()))", 56L);
-        switch (jvmVersion) {
-            case 6:
-                jrockit32Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 144L);
-                break;
-        }
-        CORRECT_SIZES.put(JvmInformation.JROCKIT_32_BIT, jrockit32Bit);
-
-        CORRECT_SIZES.put(JvmInformation.JROCKIT_64_BIT, Collections.emptyMap());
-
-        CORRECT_SIZES.put(JvmInformation.JROCKIT_64_BIT_WITH_64GB_COMPRESSED_REFS, Collections.emptyMap());
 
         Map<String, Long> ibm32Bit = new HashMap<>();
         ibm32Bit.put("sizeOf(new Object())", 16L);
@@ -233,11 +153,7 @@ public class SizeOfTestValues {
         ibm32Bit.put("deepSizeOf(new Pair(null, null))", 24L);
         ibm32Bit.put("deepSizeOf(new Pair(new Object(), null))", 40L);
         ibm32Bit.put("deepSizeOf(new Pair(new Object(), new Object()))", 56L);
-        switch (jvmVersion) {
-            case 6:
-                ibm32Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 112L);
-                break;
-        }
+
         CORRECT_SIZES.put(JvmInformation.IBM_32_BIT, ibm32Bit);
 
         Map<String, Long> ibm64Bit = new HashMap<>();
@@ -253,11 +169,7 @@ public class SizeOfTestValues {
         ibm64Bit.put("deepSizeOf(new Pair(null, null))", 40L);
         ibm64Bit.put("deepSizeOf(new Pair(new Object(), null))", 64L);
         ibm64Bit.put("deepSizeOf(new Pair(new Object(), new Object()))", 88L);
-        switch (jvmVersion) {
-            case 6:
-                ibm64Bit.put("deepSizeOf(new ReentrantReadWriteLock())", 224L);
-                break;
-        }
+
         CORRECT_SIZES.put(JvmInformation.IBM_64_BIT, ibm64Bit);
 
         CORRECT_SIZES.put(JvmInformation.IBM_64_BIT_WITH_COMPRESSED_REFS, Collections.emptyMap());

--- a/src/test/java/org/ehcache/sizeof/impl/AgentLoaderRaceTest.java
+++ b/src/test/java/org/ehcache/sizeof/impl/AgentLoaderRaceTest.java
@@ -40,13 +40,6 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
  */
 public class AgentLoaderRaceTest {
 
-    @BeforeClass
-    public static void checkForAgentLoading() {
-        Assume.assumeThat(System.getProperty("java.version"), anyOf(startsWith("1.6"), startsWith("1.7"), startsWith("1.8")));
-        Assume.assumeThat(System.getProperty("java.version"), not(startsWith("1.7.0_02")));
-        Assume.assumeThat(System.getProperty("java.vm.vendor"), not(startsWith("Apple")));
-    }
-
     /*
      * This test tries to expose an agent loading race seen in MNK-3255.
      *

--- a/src/test/java/org/ehcache/sizeof/impl/JvmInformationTest.java
+++ b/src/test/java/org/ehcache/sizeof/impl/JvmInformationTest.java
@@ -54,17 +54,6 @@ public class JvmInformationTest {
     }
 
     @Test
-    public void jrockit32Bits() {
-        verifyJvmInfo(JvmInformation.JROCKIT_32_BIT, 8, 8, 4, 8, 8, 16, 4, true, false, true);
-    }
-
-    @Test
-    public void jrockit64Bits() {
-        verifyJvmInfo(JvmInformation.JROCKIT_64_BIT, 8, 8, 4, 8, 8, 16, 4, true, false, true);
-        verifyJvmInfo(JvmInformation.JROCKIT_64_BIT_WITH_64GB_COMPRESSED_REFS, 16, 16, 4, 16, 16, 24, 4, true, false, true);
-    }
-
-    @Test
     public void ibm32Bits() {
         verifyJvmInfo(JvmInformation.IBM_32_BIT, 0, 0, 4, 8, 8, 16, 4, true, false, true);
     }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<!--
+Copyright Terracotta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Turn to DEBUG and set -Dorg.ehcache.sizeof.verboseDebugLogging=true for debugging -->
+  <logger name="org.ehcache.sizeof.ObjectGraphWalker" level="WARN"/>
+
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Note that since things might work on later JVMs, we are not checking for a JVM version anymore. In a later PR we will have to add Java 9 support.