### PR TITLE
Avoid double lookup in the visited `IdentityHashMap`

### DIFF
--- a/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
+++ b/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
@@ -39,6 +39,7 @@ final class ObjectGraphWalker {
 
     private static final Logger LOG = LoggerFactory.getLogger(ObjectGraphWalker.class);
     private static final String VERBOSE_DEBUG_LOGGING = "org.ehcache.sizeof.verboseDebugLogging";
+    private static final Object VISITED = new Object();
 
     private static final String CONTINUE_MESSAGE =
         "The configured limit of {0} object references was reached while attempting to calculate the size of the object graph." +
@@ -161,7 +162,7 @@ final class ObjectGraphWalker {
 
             Object ref = toVisit.pop();
 
-            if (visited.containsKey(ref)) {
+            if (visited.put(ref, VISITED) == VISITED) {
                 continue;
             }
 
@@ -194,7 +195,6 @@ final class ObjectGraphWalker {
                 traversalDebugMessage.append("  ignored\t")
                     .append(ref.getClass().getName()).append("@").append(System.identityHashCode(ref)).append("\n");
             }
-            visited.put(ref, null);
         }
 
         if (traversalDebugMessage != null) {


### PR DESCRIPTION
In the `ObjectGraphWalker`'s [hot loop](https://github.com/ehcache/sizeof/blob/59fb255d151a855aa005779a9e37f3a71ffb914c/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java#L161), we look up if the key is absent from the `visited: IdentityHashMap` before doing work, to then add it at the end… This PR avoids the double look up by adding the entry first, with a marker object as value, and in case the `key` was already present we skip it. Avoiding the double lookup in the case the reference hadn't been encountered yet (i.e. probably most cases)