### PR TITLE
java 11 compatibility: handle a new exception if a field is inaccessible

### DIFF
--- a/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
+++ b/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
@@ -263,6 +263,14 @@ final class ObjectGraphWalker {
                         LOG.error("Security settings prevent Ehcache from accessing the subgraph beneath '{}'" +
                                   " - cache sizes may be underestimated as a result", field, e);
                         continue;
+                    } catch (RuntimeException e) {
+                        // new class (jdk9+ only) can be thrown
+                        if (e.getClass().getSimpleName() == "InaccessibleObjectException") {
+                            LOG.error("Field access cannot be enabled. This prevents Ehcache from accessing "
+                                    + "the subgraph beneath '{}' - cache sizes may be underestimated as a result",
+                                    field, e);
+                            continue;
+                        }
                     }
                     fields.add(field);
                 }

--- a/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
+++ b/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
@@ -265,7 +265,7 @@ final class ObjectGraphWalker {
                         continue;
                     } catch (RuntimeException e) {
                         // new class (jdk9+ only) can be thrown
-                        if (e.getClass().getSimpleName() == "InaccessibleObjectException") {
+                        if ("InaccessibleObjectException".equals(e.getClass().getSimpleName())) {
                             LOG.error("Field access cannot be enabled. This prevents Ehcache from accessing "
                                     + "the subgraph beneath '{}' - cache sizes may be underestimated as a result",
                                     field, e);

--- a/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
+++ b/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
@@ -265,7 +265,7 @@ final class ObjectGraphWalker {
                         continue;
                     } catch (RuntimeException e) {
                         // new class (jdk9+ only) can be thrown
-                        if ("java.lang.reflect.InaccessibleObjectException".equals(e.getClass().getCanonicalName())) {
+                        if ("java.lang.reflect.InaccessibleObjectException".equals(e.getClass().getName())) {
                             LOG.error("JPMS blocks field access. This prevents Ehcache from accessing "
                                     + "the subgraph beneath '{}' - cache sizes may be underestimated as a result",
                                     field, e);

--- a/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
+++ b/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
@@ -266,7 +266,7 @@ final class ObjectGraphWalker {
                     } catch (RuntimeException e) {
                         // new class (jdk9+ only) can be thrown
                         if ("java.lang.reflect.InaccessibleObjectException".equals(e.getClass().getCanonicalName())) {
-                            LOG.error("Field access cannot be enabled. This prevents Ehcache from accessing "
+                            LOG.error("JPMS blocks field access. This prevents Ehcache from accessing "
                                     + "the subgraph beneath '{}' - cache sizes may be underestimated as a result",
                                     field, e);
                             continue;

--- a/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
+++ b/src/main/java/org/ehcache/sizeof/ObjectGraphWalker.java
@@ -265,7 +265,7 @@ final class ObjectGraphWalker {
                         continue;
                     } catch (RuntimeException e) {
                         // new class (jdk9+ only) can be thrown
-                        if ("InaccessibleObjectException".equals(e.getClass().getSimpleName())) {
+                        if ("java.lang.reflect.InaccessibleObjectException".equals(e.getClass().getCanonicalName())) {
                             LOG.error("Field access cannot be enabled. This prevents Ehcache from accessing "
                                     + "the subgraph beneath '{}' - cache sizes may be underestimated as a result",
                                     field, e);


### PR DESCRIPTION
- setAccessible function now throws a new exception
- catch the new exception class that appeared in java9+ only