### PR TITLE
Java 11 compatibility: Fallback to get fields by Unsafe

### DIFF
--- a/src/main/java/org/ehcache/sizeof/impl/UnsafeSizeOf.java
+++ b/src/main/java/org/ehcache/sizeof/impl/UnsafeSizeOf.java
@@ -53,6 +53,10 @@ public class UnsafeSizeOf extends SizeOf {
         UNSAFE = unsafe;
     }
 
+    public static Unsafe getUnsafe() {
+        return UNSAFE;
+    }
+
     /**
      * Builds a new SizeOf that will not filter fields and will cache reflected fields
      *


### PR DESCRIPTION
Currently, ObjectGraphWalker uses reflection to access private fields of a class. When running on Java11, this could fail if the access is denied, which results in underestimation.

This PR extends ObjectGraphWalker to use Unsafe when it fails to set a field accessable.