### PR TITLE
Update logging component versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,18 +37,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <slf4j.base.version>1.7.32</slf4j.base.version>
+        <slf4j.range.version>[${slf4j.base.version},1.7.9999)</slf4j.range.version>
+        <logback.base.version>1.2.11</logback.base.version>
+        <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.range.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>${logback.range.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This commit updates the SLF4J and Logback dependencies.

* The Logback version is set to 1.2.11; the SLF4J version is set to
  1.7.32 (the minimum needed by Logback 1.2.11).
* The use of version ranges for SLF4J and Logback is introduced.  The
  version of Logback is capped at 1.2.9999 to avoid the early versions
  of 1.3.x.  The version of SLF4J is capped at 1.7.9999 to  avoid
  picking up 1.8.0-betaX releases which will not work with released
  versions of Logback before 1.3.x.